### PR TITLE
ヘッダーを追加してTailwind cssを仮で反映させた

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,14 +6,14 @@ html
     meta[name="viewport" content="width=device-width,initial-scale=1"]
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag "application", "data-turbo-track": "reload"
+    = stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true, nonce: true
   body
-    div
-      - if current_user
-        | ログイン中 
-        strong = current_user.uid
-        | !
-        = link_to "ログアウト", signout_path, id: "sign_out"
+    nav.flex.items-center.justify-between.flex-wrap.bg-teal-500.p-6
+      div.flex.items-center.flex-shrink-0.text-white.mr-6
+        span.font-semibold.text-xl.tracking-tight Subsc.mine
+      div.w-full.block.flex-grow.lg:flex.lg:items-center.lg:w-auto
+        - if current_user
+          = link_to "ログアウト", signout_path, id: "sign_out"
     main.container.mx-auto.mt-28.px-5.flex
       = yield


### PR DESCRIPTION
## issue
- #74 

### 概要
ヘッダーを追加し、サービス名とログイン中の場合はログアウトのリンクを反映するように実装した。

![FireShot Capture 002 - SubscMine - localhost](https://user-images.githubusercontent.com/76797372/230853939-73aae920-c015-42d1-889a-3a802b1aa046.png)

### 参考資料
とりあえず本家のヘッダーを模倣した

https://v1.tailwindcss.com/components/navigation