### PR TITLE
ログインしていないのにヘッダーにログアウトボタンが表示されているバグを修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  helper_method :current_user
+  helper_method :logged_in?
 
-  def current_user
-    User.find(session[:user_id]) if session[:user_id]
+  private
+
+  def logged_in?
+    !!session[:user_id]
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module SessionsHelper
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,7 +13,7 @@ html
       .flex.items-center.flex-shrink-0.text-white.mr-6
         span.font-semibold.text-xl.tracking-tight Subsc.mine
       .w-full.block.flex-grow.lg:flex.lg:items-center.lg:w-auto
-        - if current_user
+        - if logged_in?
           = link_to 'ログアウト', signout_path, id: 'sign_out'
     main.container.mx-auto.mt-28.px-5.flex
       = yield


### PR DESCRIPTION
ログイン前のヘッダーにログアウトボタンが表示されていたため、`logged_in?` メソッドを定義して判定するようにした。