### PR TITLE
サブスクリプション登録画面と一覧表示画面を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,8 @@ class ApplicationController < ActionController::Base
   def logged_in?
     !!session[:user_id]
   end
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,9 +1,31 @@
 # frozen_string_literal: true
 
 class SubscriptionsController < ApplicationController
-  def index; end
+  def index
+    @subscriptions = current_user.subscriptions
+  end
 
-  def new; end
+  def show; end
+
+  def new
+    @subscription = Subscription.new
+  end
+
+  def create
+    subscription = current_user.subscriptions.new(subscription_params)
+    subscription.save!
+    redirect_to root_path, notice: "サブスクリプション「#{subscription.name}」を登録しました。"
+  end
 
   def edit; end
+
+  def update; end
+
+  def delete; end
+
+  private
+
+  def subscription_params
+    params.require(:subscription).permit(:name, :payment_date, :fee, :my_account_url, :subscribed, :cycle, :user_id)
+  end
 end

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <h1>{{ message }}</h1>
-    <p><input v-model="message" /></p>
   </div>
 </template>
 
@@ -13,7 +12,7 @@ export default {
     };
   },
   created() {
-    this.message = "hello";
+    this.message = "Subsc.mineでサブスクリプションを管理しよう！";
   },
 };
 </script>

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,3 @@
+class Subscription < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ApplicationRecord
   validates :uid, uniqueness: { scope: :provider }
 
+  has_many :subscriptions
+
   def self.from_omniauth(auth_hash)
     provider = auth_hash[:provider]
     uid = auth_hash[:uid]

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,5 +18,5 @@ html
     .container
       - if flash.notice.present?
         .alert.alert-success.bg-orange-100.border-l-4.border-orange-500.text-orange-700.p-4 = flash.notice
-    main.container.mx-auto.mt-28.px-5.flex
+    main.container.mx-auto.mt-28.px-5
       = yield

--- a/app/views/subscriptions/index.html.slim
+++ b/app/views/subscriptions/index.html.slim
@@ -1,5 +1,27 @@
 #app
-  h1.font-bold.text-4xl
-    | Subscriptions#index
-  p
-    | Find me in app/views/subscriptions/index.html.erb
+
+.bg-blue-500.w-32.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
+    = link_to '新規登録', new_subscription_path
+
+.my-5
+  - @subscriptions.each do |subscription|
+    table.min-w-full.text-left.text-sm.font-light
+      tbody
+          tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
+            th = Subscription.human_attribute_name(:name)
+            td = subscription.name
+          tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+            th = Subscription.human_attribute_name(:payment_date)
+            td = subscription.payment_date
+          tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
+            th = Subscription.human_attribute_name(:fee)
+            td = subscription.fee
+          tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+            th = Subscription.human_attribute_name(:my_account_url)
+            td = subscription.my_account_url
+          tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
+            th = Subscription.human_attribute_name(:subscribed)
+            td = subscription.subscribed
+          tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+            th = Subscription.human_attribute_name(:cycle)
+            td = subscription.cycle

--- a/app/views/subscriptions/new.html.slim
+++ b/app/views/subscriptions/new.html.slim
@@ -1,0 +1,32 @@
+h1 サブスクリプションの新規登録
+
+.nav.justify-content-end.bg-blue-500.w-24.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
+  = link_to '一覧', subscriptions_path
+
+=form_with model: @subscription, local: true do |f|
+  - if @subscription.errors.any?
+      #error_explanation.message.is-light
+        ul
+          - @subscription.errors.full_messages.each do |message|
+            li.message-body = message
+  .my-5
+    = f.label :name
+    = f.text_field :name, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2"
+  .my-5
+    = f.label :payment_date
+    = f.date_field :payment_date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2"
+  .my-5
+    = f.label :fee
+    = f.number_field :fee, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2"
+  .my-5
+    = f.label :my_account_url
+    = f.url_field :my_account_url, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2"
+  .my-5
+    = f.label :subscribed
+    = f.select :subscribed, [['停止中', false], ['継続中', true]], { include_blank: true, selected: true },
+      class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-24"
+  .my-5
+    = f.label :cycle
+    = f.select :cycle, [[1, 1], [2, 2], [3, 3], [6, 6], [12, 12]], { include_blank: '選択してください' },
+      class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-48"
+  = f.submit nil, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,2 +1,2 @@
-.bg-blue-500.w-75.hover:bg-blue-700.text-white.font-bold.py-2.px-4.border.border-blue-700.rounded
+.bg-blue-500.w-48.hover:bg-blue-700.text-white.font-bold.py-2.px-4.border.border-blue-700.rounded
   = button_to "Googleアカウントでログイン", "/auth/google_oauth2/"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,16 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    models:
+      subscriptions: サブスクリプション
+    attributes:
+      subscription:
+        name: サービス名
+        payment_date: お支払日
+        fee: お支払い金額
+        my_account_url: マイアカウントURL
+        subscribed: 購読有無
+        cycle: 周期
   date:
     abbr_day_names:
     - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   resources :sessions, only: %i(new create destroy)
   resources :welcome, only: %i(index)
-  resources :subscriptions, only: %i(index new edit)
+  resources :subscriptions
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/db/migrate/20230412094208_create_subscriptions.rb
+++ b/db/migrate/20230412094208_create_subscriptions.rb
@@ -1,0 +1,14 @@
+class CreateSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :subscriptions do |t|
+      t.string :name, null: false
+      t.date :payment_date, null: false
+      t.integer :fee, null: false
+      t.string :my_account_url
+      t.boolean :subscribed, default: false, null: false
+      t.integer :cycle, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230412094915_add_user_id_to_subscriptions.rb
+++ b/db/migrate/20230412094915_add_user_id_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddUserIdToSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :subscriptions, :user, null: false, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_09_035916) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_12_094915) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "subscriptions", force: :cascade do |t|
+    t.string "name", null: false
+    t.date "payment_date", null: false
+    t.integer "fee", null: false
+    t.string "my_account_url"
+    t.boolean "subscribed", default: false, null: false
+    t.integer "cycle", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_subscriptions_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", null: false


### PR DESCRIPTION
## issue
- #20 
- #21 
- #39 
- #42 

### 概要
サブスクリプション登録画面と一覧表示画面を実装

![FireShot Capture 007 - SubscMine - localhost](https://user-images.githubusercontent.com/76797372/231947594-889b12c3-89f4-445a-bc6a-c491f8ac4c56.png)

![FireShot Capture 008 - SubscMine - localhost](https://user-images.githubusercontent.com/76797372/231947670-ec8030fb-5e4b-4352-bbaa-9b8669c730af.png)

表示方法やCSSがおかしいのは別で直す。
edit画面を実装する際に `new.html.slim` はパーシャル化する。