### PR TITLE
ボタンのメソッドをlink_toからbutton_toに置き換えた

### DIFF
--- a/app/views/subscriptions/index.html.slim
+++ b/app/views/subscriptions/index.html.slim
@@ -1,7 +1,7 @@
 #app
 
-.bg-blue-500.w-32.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
-    = link_to '新規登録', new_subscription_path
+.bg-blue-500.w-28.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
+    = button_to '新規登録', new_subscription_path, method: :get
 
 - @subscriptions.each do |subscription|
   .my-10
@@ -27,7 +27,7 @@
             td = subscription.cycle
           tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
             th = '操作'
-            td = link_to '編集', edit_subscription_path(subscription), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+            td = button_to '編集', edit_subscription_path(subscription), method: :get, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
           tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
             th = '操作'
-            td = link_to '削除', subscription, data: { turbo_method: :delete, turbo_confirm: "サブスクリプション「 #{subscription.name} 」を削除します。よろしいですか?" }, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+            td = button_to '削除', subscription, method: :delete, data: { turbo_confirm: "サブスクリプション「 #{subscription.name} 」を削除します。よろしいですか?" }, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"


### PR DESCRIPTION
## issue
- #102 
### 概要
CSSをまだ調整しきれていないため、ボタンが被って見えてしまう。
一時的に`button_to` に変えてボタン同士が被らないようにした。
（処理的には `button_to` のままでも問題ないため、このままで行くかも）

![FireShot Capture 018 - SubscMine - localhost](https://user-images.githubusercontent.com/76797372/232385281-4ed60a4a-92f3-47cc-8241-aa8a86a79440.png)
