### PR TITLE
subscribedのboolean値をviewでは継続中または停止中で出すように修正した

### DIFF
--- a/app/decorators/subscription_decorator.rb
+++ b/app/decorators/subscription_decorator.rb
@@ -1,2 +1,5 @@
 module SubscriptionDecorator
+  def subscribed_status
+    subscribed ? '継続中' : '停止中'
+  end
 end

--- a/app/views/subscriptions/index.html.slim
+++ b/app/views/subscriptions/index.html.slim
@@ -24,7 +24,7 @@
             td = subscription.my_account_url
           tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
             th = Subscription.human_attribute_name(:subscribed)
-            td = subscription.subscribed
+            td = subscription.subscribed_status
           tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
             th = Subscription.human_attribute_name(:cycle)
             td = subscription.cycle


### PR DESCRIPTION
## issue
- #125 
### 概要
viewに`subscribed` の表示がbooleanの `true` `false` でそのまま出ていたため、ActiveDecoratorで「継続中」「停止中」として出すように修正した

<img width="1148" alt="サブスクステータス" src="https://user-images.githubusercontent.com/76797372/233250931-ba5c0ccc-592f-42b2-9d28-c26d2c17789c.png">
