### PR TITLE
my_account_urlを別タブで開くようにリンク化した（セキュリティ再チェック要）

### DIFF
--- a/app/views/subscriptions/index.html.slim
+++ b/app/views/subscriptions/index.html.slim
@@ -21,7 +21,7 @@
             td = subscription.fee
           tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
             th = Subscription.human_attribute_name(:my_account_url)
-            td = subscription.my_account_url
+            td = link_to subscription.my_account_url.to_s, subscription.my_account_url, target: :_blank, rel: "noopener noreferrer"
           tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
             th = Subscription.human_attribute_name(:subscribed)
             td = subscription.subscribed_status


### PR DESCRIPTION
## issue
- #127 
### 概要
viewに表示されていたmy_account_urlがただの文字列だったため、リンク化して別タブで開けるようにした。

```
target: :_blank, rel: "noopener noreferrer"
```

を指定してセキュリティも考慮したつもりでいるけど、本当にこれで大丈夫か最新情報の確認必須

### 参考資料
https://qiita.com/Hal_mai/items/94b7d5c7e00c72324013
https://qiita.com/Kazuhiro_Mimaki/items/b3f2d718d2bae9083290
