### PR TITLE
サブスクのステータス更新モーダルをHotwireで実装

### DIFF
--- a/app/controllers/subscriptions/status_controller.rb
+++ b/app/controllers/subscriptions/status_controller.rb
@@ -1,0 +1,22 @@
+module Subscriptions
+  class StatusController < ApplicationController
+    before_action :set_subscription, only: %i[edit update]
+
+    def edit; end
+
+    def update
+      @subscription.update!(subscription_params)
+      redirect_to root_path, notice: "サブスクリプション「#{@subscription.name}」を編集しました。"
+    end
+
+    private
+
+    def subscription_params
+      params.require(:subscription).permit(:name, :payment_date, :fee, :my_account_url, :subscribed, :cycle, :user_id)
+    end
+
+    def set_subscription
+      @subscription = Subscription.find(params[:id])
+    end
+  end
+end

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus";
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!";
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,6 +3,6 @@
 // ./bin/rails generate stimulus controllerName
 
 import { application } from "./application";
-
 import ModalController from "./modal_controller";
+
 application.register("modal", ModalController);

--- a/app/views/subscriptions/index.html.slim
+++ b/app/views/subscriptions/index.html.slim
@@ -1,41 +1,44 @@
-#app
-
 .bg-blue-500.w-28.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
     = button_to '新規登録', new_subscription_path, method: :get
 .bg-blue-500.w-48.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
     = button_to 'カレンダー連携', subscriptions_calendars_url(protocol: :webcal, format: :ics)
 
 - @subscriptions.each do |subscription|
-  .my-10
-    table.min-w-full.text-left.text-sm.font-light.border.dark:border-zinc-950
-      tbody
-          tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
-            th = Subscription.human_attribute_name(:name)
-            td = subscription.name
-          tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
-            th = Subscription.human_attribute_name(:payment_date)
-            td = subscription.payment_date
-          tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
-            th = '次回お支払い予定日'
-            td = I18n.l subscription.calc_next_payment_date, format: :short
-          tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
-            th = Subscription.human_attribute_name(:fee)
-            td = subscription.fee
-          tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
-            th = Subscription.human_attribute_name(:my_account_url)
-            td = link_to subscription.my_account_url.to_s, subscription.my_account_url, target: :_blank, rel: "noopener noreferrer"
-          tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
-            th = Subscription.human_attribute_name(:subscribed)
-            td = subscription.subscribed_status
-          tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
-            th = Subscription.human_attribute_name(:cycle)
-            td = subscription.cycle
-          tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
-            th = '操作'
-            td = button_to '編集', edit_subscription_path(subscription), method: :get, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-          tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
-            th = '操作'
-            td = button_to '削除', subscription, method: :delete, data: { turbo_confirm: "サブスクリプション「 #{subscription.name} 」を削除します。よろしいですか?" }, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+  a.block.max-w.my-5.p-6.bg-white.border.border-gray-200.rounded-lg.shadow.hover:bg-gray-100.dark:bg-gray-800.dark:border-gray-700.dark:hover:bg-gray-700
+    .my-10
+      table.min-w-full.text-left.text-sm.font-light.border.dark:border-zinc-950
+        tbody.leading-10
+            tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
+              th = Subscription.human_attribute_name(:name)
+              td = subscription.name
+            tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+              th = Subscription.human_attribute_name(:payment_date)
+              td = subscription.payment_date
+            tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+              th = '次回お支払い予定日'
+              td = I18n.l subscription.calc_next_payment_date, format: :short
+            tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
+              th = Subscription.human_attribute_name(:fee)
+              td = subscription.fee
+            tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+              th = Subscription.human_attribute_name(:my_account_url)
+              td = link_to subscription.my_account_url.to_s, subscription.my_account_url, target: :_blank, rel: "noopener noreferrer"
+            tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
+              th = Subscription.human_attribute_name(:subscribed)
+              td = subscription.subscribed_status
+            tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+              th = Subscription.human_attribute_name(:cycle)
+              td = subscription.cycle
+      .bg-blue-500.w-48.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
+        = button_to 'ステータス変更', edit_subscriptions_status_path(subscription), method: :get, data: { turbo_frame: 'status' }
+      .hidden.fixed.m-auto.w-screen.h-screen.top-0.left-0.bg-gray-700/50.z-10 data-controller="modal" data-modal-target="modal" data-action="turbo:frame-load->modal#open turbo:submit-end->modal#close"
+        .absolute.top-1/2.left-1/2.-translate-x-1/2.-translate-y-1/2.w-max.h-max.bg-white.p-10
+          = turbo_frame_tag "status"
+      .bg-blue-500.w-28.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
+        = button_to '編集', edit_subscription_path(subscription), method: :get
+      .bg-blue-500.w-28.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
+        = button_to '削除', subscription, method: :delete, data: { turbo_confirm: "サブスクリプション「 #{subscription.name} 」を削除します。よろしいですか?" }
+
 .w-24.hover:text-blue-600.py-2.px-4.my-5
   = link_to '退会', new_retirements_path, data: { turbo_frame: 'retirements' }
 .hidden.fixed.m-auto.w-screen.h-screen.top-0.left-0.bg-gray-700/50.z-10 data-controller="modal" data-modal-target="modal" data-action="turbo:frame-load->modal#open turbo:submit-end->modal#close"

--- a/app/views/subscriptions/status/_form.html.slim
+++ b/app/views/subscriptions/status/_form.html.slim
@@ -1,0 +1,14 @@
+=form_with model: subscription, local: true do |f|
+  - if @subscription.errors.any?
+      #error_explanation.message.is-light
+        ul
+          - subscription.errors.full_messages.each do |message|
+            li.message-body = message
+  .my-5
+    = f.label :subscribed
+    = f.select :subscribed, [['停止中', false], ['継続中', true]], { include_blank: true, selected: true }, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2"
+  - unless @subscription.subscribed
+    .my-5
+      = f.label :payment_date
+      = f.date_field :payment_date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2"
+  = f.submit nil, data: { turbo: "false" }, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/app/views/subscriptions/status/edit.html.slim
+++ b/app/views/subscriptions/status/edit.html.slim
@@ -1,0 +1,4 @@
+= turbo_frame_tag "status" do
+  h1 サブスクリプションの編集画面
+
+  = render partial: 'form', locals: { subscription: @subscription }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   namespace :subscriptions do
     resources :calendars, only: %i(index)
+    resources :status, only: %i(edit update)
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
## issue
- #120 
### 概要
編集画面にいかなくてもサブスクのステータス更新モーダル上で「継続」「停止」の更新が行えるようにした

![FireShot Capture 020 - SubscMine - localhost](https://user-images.githubusercontent.com/76797372/233758081-cd06fdb3-f3e0-4a41-b50d-2a0804600b57.png)

※CSSは別issueで直す
### 参考資料
- https://postd.cc/how-dhh-organizes-his-rails-controllers/