### PR TITLE
ログイン後の画面のCSSを見直した（モダールのみ要調査)

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,15 +9,15 @@ html
     = stylesheet_link_tag 'tailwind', 'inter-font', 'data-turbo-track': 'reload'
     = javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true, nonce: true
   body
-    nav.flex.items-center.justify-between.flex-wrap.bg-teal-500.p-6
+    nav.flex.justify-start.bg-teal-500.p-6
       .flex.items-center.flex-shrink-0.text-white.mr-6
         span.font-semibold.text-xl.tracking-tight Subsc.mine
-      .w-full.block.flex-grow.lg:flex.lg:items-center.lg:w-auto
+      .flex.items-center.flex-shrink-0.text-white.mr-6
         - if logged_in?
           = link_to 'ログアウト', signout_path, id: 'sign_out'
     .container
       - if flash.notice.present?
-        .alert.alert-success.bg-orange-100.border-l-4.border-orange-500.text-orange-700.p-4 = flash.notice
+        .alert.w-screen.bg-orange-100.border-l-4.border-orange-500.text-orange-700.p-4 = flash.notice
     main.container.mx-auto.mt-28.px-5
       = yield
     footer.footer.is-size-7

--- a/app/views/retirements/new.html.slim
+++ b/app/views/retirements/new.html.slim
@@ -1,12 +1,15 @@
 = turbo_frame_tag "retirements" do
 
-  h2.title.is-2.my-6 アカウント削除確認画面
+  h1.font-semibold.text-xl アカウント削除確認画面
 
-  p.my-4 アカウントを削除した場合、登録したサブスクリプションが全て削除されます。
+  p.my-4 ※アカウントを削除した場合、登録したサブスクリプションが全て削除されます。
+  p.my-4 ※この操作は取り消せません。
 
-  = button_to 'アカウントを削除する', retirements_path,
-    class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded', data: { cturbo_confirm: '本当に削除しますか？' }
-  .has-text-left.pt-5
-
-  = button_to 'キャンセル', subscriptions_path, method: :get, data: { turbo: "false" },
-    class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded'
+  .flex.flex-initial
+    .flex.items-center.flex-shrink-0.mr-10
+      = button_to 'アカウントを削除する', retirements_path,
+        class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded', data: { cturbo_confirm: '本当に削除しますか？' }
+      .has-text-left.pt-5
+    .flex.items-center.flex-shrink-0.mr-10
+      = button_to 'キャンセル', subscriptions_path, method: :get, data: { turbo: "false" },
+        class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded'

--- a/app/views/subscriptions/edit.html.slim
+++ b/app/views/subscriptions/edit.html.slim
@@ -1,6 +1,6 @@
-h1 サブスクリプションの編集画面
-
-.nav.justify-content-end.bg-blue-500.w-24.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
-  = link_to '一覧', subscriptions_path
+h1.font-semibold.text-xl サブスクリプションの編集
+.flex.flex-initial
+  .mt-5.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
+    = link_to '一覧', subscriptions_path
 
 = render partial: 'form', locals: { subscription: @subscription }

--- a/app/views/subscriptions/index.html.slim
+++ b/app/views/subscriptions/index.html.slim
@@ -1,46 +1,50 @@
-.bg-blue-500.w-28.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
-    = button_to '新規登録', new_subscription_path, method: :get
-.bg-blue-500.w-48.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
-    = button_to 'カレンダー連携', subscriptions_calendars_url(protocol: :webcal, format: :ics)
+.flex.flex-initial
+  .flex.items-center.flex-shrink-0.mr-10
+    .bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
+        = button_to '新規登録', new_subscription_path, method: :get
+  .flex.items-center.flex-shrink-0
+    .bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
+        = button_to 'カレンダー連携', subscriptions_calendars_url(protocol: :webcal, format: :ics)
 
 - @subscriptions.each do |subscription|
   a.block.max-w.my-5.p-6.bg-white.border.border-gray-200.rounded-lg.shadow.hover:bg-gray-100.dark:bg-gray-800.dark:border-gray-700.dark:hover:bg-gray-700
     .my-10
-      table.min-w-full.text-left.text-sm.font-light.border.dark:border-zinc-950
+      table.min-w-full.text-left.text-base.border.dark:border-zinc-950
         tbody.leading-10
-            tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
+            tr.border-b
               th = Subscription.human_attribute_name(:name)
               td = subscription.name
-            tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+            tr.border-b
               th = Subscription.human_attribute_name(:payment_date)
               td = subscription.payment_date
-            tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+            tr.border-b
               th = '次回お支払い予定日'
               td = I18n.l subscription.calc_next_payment_date, format: :short
-            tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
+            tr.border-b
               th = Subscription.human_attribute_name(:fee)
               td = subscription.fee
-            tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+            tr.border-b
               th = Subscription.human_attribute_name(:my_account_url)
               td = link_to subscription.my_account_url.to_s, subscription.my_account_url, target: :_blank, rel: "noopener noreferrer"
-            tr.border-b.bg-neutral-100.dark:border-neutral-500.dark:bg-neutral-700
+            tr.border-b
               th = Subscription.human_attribute_name(:subscribed)
               td = subscription.subscribed_status
-            tr.border-b.bg-white.dark:border-neutral-500.dark:bg-neutral-600
+            tr.border-b
               th = Subscription.human_attribute_name(:cycle)
               td = subscription.cycle
-      .bg-blue-500.w-48.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
-        = button_to 'ステータス変更', edit_subscriptions_status_path(subscription), method: :get, data: { turbo_frame: 'status' }
-      .hidden.fixed.m-auto.w-screen.h-screen.top-0.left-0.bg-gray-700/50.z-10 data-controller="modal" data-modal-target="modal" data-action="turbo:frame-load->modal#open turbo:submit-end->modal#close"
-        .absolute.top-1/2.left-1/2.-translate-x-1/2.-translate-y-1/2.w-max.h-max.bg-white.p-10
-          = turbo_frame_tag "status"
-      .bg-blue-500.w-28.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
-        = button_to '編集', edit_subscription_path(subscription), method: :get
-      .bg-blue-500.w-28.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
-        = button_to '削除', subscription, method: :delete, data: { turbo_confirm: "サブスクリプション「 #{subscription.name} 」を削除します。よろしいですか?" }
+      .flex.justify-center
+        .mt-10.mr-10.flex-wrap.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
+          = button_to 'ステータス変更', edit_subscriptions_status_path(subscription), method: :get, data: { turbo_frame: 'status' }
+        .hidden.fixed.m-auto.w-screen.h-screen.top-0.left-0.bg-gray-700/50.z-10 data-controller="modal" data-modal-target="modal" data-action="turbo:frame-load->modal#open turbo:submit-end->modal#close"
+          .absolute.top-1/2.left-1/2.-translate-x-1/2.-translate-y-1/2.w-max.h-max.bg-white.p-10
+            = turbo_frame_tag "status"
+        .mt-10.mr-10.flex-wrap.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
+          = button_to '編集', edit_subscription_path(subscription), method: :get
+        .mt-10.flex-wrap.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
+          = button_to '削除', subscription, method: :delete, data: { turbo_confirm: "サブスクリプション「 #{subscription.name} 」を削除します。よろしいですか?" }
 
 .w-24.hover:text-blue-600.py-2.px-4.my-5
   = link_to '退会', new_retirements_path, data: { turbo_frame: 'retirements' }
 .hidden.fixed.m-auto.w-screen.h-screen.top-0.left-0.bg-gray-700/50.z-10 data-controller="modal" data-modal-target="modal" data-action="turbo:frame-load->modal#open turbo:submit-end->modal#close"
-  .absolute.top-1/2.left-1/2.-translate-x-1/2.-translate-y-1/2.w-max.h-max.bg-white.p-10
+  .absolute.top-1/2.left-1/2.-translate-x-1/2.-translate-y-1/2.w-full.sm:w-max.h-full.sm:h-max.bg-white.p-10
     = turbo_frame_tag "retirements"

--- a/app/views/subscriptions/new.html.slim
+++ b/app/views/subscriptions/new.html.slim
@@ -1,6 +1,7 @@
-h1 サブスクリプションの新規登録
+h1.font-semibold.text-xl サブスクリプションの新規登録
 
-.nav.justify-content-end.bg-blue-500.w-24.hover:bg-blue-700.text-white.font-bold.py-2.px-4.my-10.border.border-blue-700.rounded
-  = link_to '一覧', subscriptions_path
+.flex.flex-initial
+  .mt-5.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
+    = link_to '一覧', subscriptions_path
 
 = render partial: 'form', locals: { subscription: @subscription }

--- a/app/views/subscriptions/status/_form.html.slim
+++ b/app/views/subscriptions/status/_form.html.slim
@@ -11,4 +11,6 @@
     .my-5
       = f.label :payment_date
       = f.date_field :payment_date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2"
-  = f.submit nil, data: { turbo: "false" }, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+  = f.submit nil, data: { turbo: "false" }, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 mr-5 rounded"
+  = button_to 'キャンセル', subscriptions_path, method: :get, data: { turbo: "false" },
+    class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 mt-10 rounded'

--- a/app/views/subscriptions/status/edit.html.slim
+++ b/app/views/subscriptions/status/edit.html.slim
@@ -1,4 +1,4 @@
 = turbo_frame_tag "status" do
-  h1 サブスクリプションの編集画面
+  h1.font-semibold.text-xl サブスクリプションの編集画面
 
   = render partial: 'form', locals: { subscription: @subscription }


### PR DESCRIPTION
## issue
- #138 
### 概要
ログイン後の画面全般のCSSをスマホ含めて調整した。
モーダルだけスマホの時にモーダル位置を固定して背景を透過させるのができていない