### PR TITLE
プリロードのエラーを解消

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,7 +6,7 @@ html
     meta[name='viewport' content='width=device-width,initial-scale=1']
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag 'tailwind', 'inter-font', 'data-turbo-track': 'reload'
+    = stylesheet_link_tag 'tailwind', 'inter-font', 'data-turbo-track': 'reload', defer: true
     = javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true, nonce: true
   body
     nav.flex.justify-start.bg-teal-500.p-6


### PR DESCRIPTION
## issue
- #148 
### 概要
フラッシュメッセージが出る際に以下のエラーが発生していた。
`head` 内に強制的にリロードの設定を書くとフラッシュメッセージが出なくなるため、`defer` を追加して対応した。

```
e resource http://localhost:3000/assets/tailwind-7e3a2781f0ad9f5199f4a83570547bc79be5b99469dd1b9769399f909991806e.css was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.
```