### PR TITLE
データ登録時のバリデーションの見直しとエラーが表示されないバグを修正

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -14,9 +14,12 @@ class SubscriptionsController < ApplicationController
   end
 
   def create
-    subscription = current_user.subscriptions.new(subscription_params)
-    subscription.save!
-    redirect_to root_path, notice: "サブスクリプション「#{subscription.name}」を登録しました。"
+    @subscription = current_user.subscriptions.new(subscription_params)
+    if @subscription.save
+      redirect_to root_path, notice: "サブスクリプション「#{@subscription.name}」を登録しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def edit; end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,4 +1,12 @@
 class Subscription < ApplicationRecord
+  validates :name, length: { maximum: 50 }, presence: true
+  validates :payment_date, presence: true
+  validates :fee, length: { maximum: 7 }, presence: true
+  validates :my_account_url, length: { maximum: 200 }
+  validates :subscribed, presence: true
+  validates :cycle, presence: true
+  validate :payment_date_before_this_month
+
   belongs_to :user
 
   def calc_next_payment_date
@@ -30,5 +38,13 @@ class Subscription < ApplicationRecord
       duration
     end
     duration
+  end
+
+  def payment_date_before_this_month
+    return if payment_date.blank?
+
+    return unless payment_date.month > Date.today.month
+
+    errors.add("お支払基準日は今月以前の直近の日付を指定してください。")
   end
 end

--- a/app/views/subscriptions/_form.html.slim
+++ b/app/views/subscriptions/_form.html.slim
@@ -1,9 +1,8 @@
-=form_with model: subscription, local: true do |f|
-  - if @subscription.errors.any?
-      #error_explanation.message.is-light
-        ul
+=form_with model: subscription do |f|
+  - if subscription.errors.any?
+        ul.mt-5.bg-red-100.border.border-red-400.text-red-700.px-4.py-3.w-max.rounded
           - subscription.errors.full_messages.each do |message|
-            li.message-body = message
+            li.message-body.mt-3 = message
   .my-5
     = f.label :name
     = f.text_field :name, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2"


### PR DESCRIPTION
## 概要
- Subscriptionモデルにバリデーションを追加した
- サブスクのデータ登録時にエラーが表示されていなかったため修正した
### 参考リンク
https://zenn.dev/komaken/articles/1553fedceea765
https://qiita.com/P-man_Brown/items/862503a638801fea01e7
https://medium.com/lightthefuse/ruby-on-rails-date-validation-in-a-booking-and-disabling-dates-in-date-picker-3e5b4e9b4640