### PR TITLE
日付計算とvalidation、該当のvalidationテストの修正

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -25,8 +25,11 @@ class SubscriptionsController < ApplicationController
   def edit; end
 
   def update
-    @subscription.update!(subscription_params)
-    redirect_to root_path, notice: "サブスクリプション「#{@subscription.name}」を編集しました。"
+    if @subscription.update(subscription_params)
+      redirect_to root_path, notice: "サブスクリプション「#{@subscription.name}」を編集しました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy

--- a/app/views/subscriptions/_form.html.slim
+++ b/app/views/subscriptions/_form.html.slim
@@ -1,8 +1,8 @@
 =form_with model: subscription do |f|
   - if subscription.errors.any?
-        ul.mt-5.bg-red-100.border.border-red-400.text-red-700.px-4.py-3.w-max.rounded
+        ul.my-5.bg-red-100.border.border-red-400.text-red-700.px-4.py-3.w-max.rounded
           - subscription.errors.full_messages.each do |message|
-            li.message-body.mt-3 = message
+            li.message-body.my-3 = message
   .my-5
     = f.label :name
     = f.text_field :name, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2"

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -65,11 +65,11 @@ RSpec.describe Subscription, type: :model do
     valid_payment_date = Date.parse('2023/04/30')
     subscription = build(:subscription, payment_date: valid_payment_date)
     subscription.valid?
-    expect(subscription.errors).not_to include('お支払基準日は今月以前の直近の日付を指定してください。')
+    expect(subscription.errors[:payment_date]).not_to include('お支払基準日は今月以前の直近の日付を指定してください。')
 
     invalid_payment_date = Date.parse('2023/05/01')
     subscription = build(:subscription, payment_date: invalid_payment_date)
     subscription.valid?
-    expect(subscription.errors).to include('お支払基準日は今月以前の直近の日付を指定してください。')
+    expect(subscription.errors[:payment_date]).to include('お支払基準日は今月以前の直近の日付を指定してください。')
   end
 end


### PR DESCRIPTION
## 概要
- 次回お支払日の算出コードを見直し、コメントを残すようにした
- カスタムバリデーターの実装が間違っていたため修正
- それに伴い、モデルのテストも修正した