### PR TITLE
退会した際にユーザーに紐づくサブスクが消えていなかったため修正

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -7,7 +7,7 @@ class Subscription < ApplicationRecord
   validates :cycle, presence: true
   validate :payment_date_before_this_month
 
-  belongs_to :user
+  belongs_to :user, dependent: :destroy
 
   def calc_next_payment_date
     duration = calc_duration


### PR DESCRIPTION
## 概要
退会した際にユーザーに紐づくサブスクが消えていなかったため修正した