### PR TITLE
サブスクの並び順が制御されていなかったため作成順で降順で出すようにした。

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -4,7 +4,7 @@ class SubscriptionsController < ApplicationController
   before_action :set_subscription, only: %i[edit update destroy]
 
   def index
-    @subscriptions = current_user.subscriptions
+    @subscriptions = current_user.subscriptions.order(created_at: :DESC)
   end
 
   def show; end


### PR DESCRIPTION
## 概要
サブスクの表示順が制御されておらず、更新のたびに入れ替わるため、作成順で降順で出すようにした。
### 参考資料
https://pikawaka.com/rails/order