### PR TITLE
サブスクを削除するとユーザーが退会扱いになるバグを修正した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 class User < ApplicationRecord
   validates :uid, uniqueness: { scope: :provider }
 
-  has_many :subscriptions
+  has_many :subscriptions, dependent: :destroy
 
   def self.from_omniauth(auth_hash)
     provider = auth_hash[:provider]


### PR DESCRIPTION
## 概要
マージしてはいけないPRを誤ってマージしていた（テストもなかった・・・）ため、revertして修正した