### PR TITLE
PC表示の際のロゴが大きすぎたため際のロゴが大きすぎたためブレークポイントを設定

### DIFF
--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -2,7 +2,7 @@ block.max-w
   .max-w
     h1.text-center.font-bold.text-zinc-500.md:text-2xl 次のお支払日いつだっけ？を解決する
   .max-w
-    = image_tag 'logo500px.png', class: 'm-auto w-6/12'
+    = image_tag 'logo500px.png', class: 'm-auto w-6/12 md:w-3/12'
   .mt-10.mb-10
     .bg-blue-500.w-48.hover:bg-blue-700.text-white.font-bold.py-2.px-4.border.border-blue-700.rounded.m-auto
       = button_to "Googleアカウントでログイン", "/auth/google_oauth2/", data: { turbo: "false" }


### PR DESCRIPTION
## issue
- #195 
### 概要
PCでログイン画面を開いた際のロゴが大きすぎたため、ブレークポイントを設定した

![FireShot Capture 029 - サブスクの次回お支払日を管理 Subsc mine - localhost](https://user-images.githubusercontent.com/76797372/236115170-bfd00ef5-b0c8-4637-9ff4-0215d827c403.png)
