### PR TITLE
カレンダー連携用のURLに渡す情報の渡し方を見直し

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  def show
-    @user_id = current_user.id
-  end
+  def show; end
 end

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -6,7 +6,7 @@
     li.list-disc.my-1 ご利用のOSやアプリによってiCalendarの連携が動作しない場合があります。その場合はPCのGoogleカレンダーから連携をお試しください。
   .flex.flex-initial.flex-wrap
     .flex.items-center.flex-shrink-0.mr-10
-      = link_to 'カレンダーと連携する', user_subscriptions_url(protocol: :webcal, format: :ics, user_id: @user_id),
+      = link_to 'カレンダーと連携する', user_subscriptions_url(protocol: :webcal, format: :ics, user_id: current_user),
         class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mt-5'
     .flex.items-center.flex-shrink-0.mr-10
       = button_to '戻る', subscriptions_path, method: :get, data: { turbo: 'false' },


### PR DESCRIPTION
## issue
- #215 
### 概要
カレンダー連携時のuser_idの渡し方についてレビューをいただいたため修正した