### PR TITLE
カレンダー連携時のURLに含まれるuser_idをMD5で暗号化した

### DIFF
--- a/app/controllers/users/subscriptions_controller.rb
+++ b/app/controllers/users/subscriptions_controller.rb
@@ -17,7 +17,8 @@ module Users
     private
 
     def set_export
-      Subscription.where(user_id: params[:user_id], subscribed: true)
+      user = User.find_by(id_digest: params[:user_id])
+      Subscription.where(user_id: user.id, subscribed: true)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  after_save :create_id_digest
   validates :uid, uniqueness: { scope: :provider }
 
   has_many :subscriptions, dependent: :destroy
@@ -9,5 +10,18 @@ class User < ApplicationRecord
     provider = auth_hash[:provider]
     uid = auth_hash[:uid]
     User.where(provider:, uid:).first_or_initialize
+  end
+
+  def to_param
+    id_digest
+  end
+
+  private
+
+  def create_id_digest
+    return unless id_digest.nil?
+
+    new_digest = Digest::MD5.hexdigest(id.to_s)
+    update_column(:id_digest, new_digest)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,6 @@ class User < ApplicationRecord
     return unless id_digest.nil?
 
     new_digest = Digest::MD5.hexdigest(id.to_s)
-    update_column(:id_digest, new_digest)
+    update_attribute(:id_digest, new_digest)
   end
 end

--- a/db/migrate/20230506132131_add_id_digest_to_users.rb
+++ b/db/migrate/20230506132131_add_id_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddIdDigestToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :id_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_12_094915) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_06_132131) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_12_094915) do
     t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "id_digest"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 


### PR DESCRIPTION
## issue
- #217 
### 概要
カレンダー連携の際のURLにuser_idがそのまま含まれていて、書き換えて他のデータを連携しようとすればできてしまう状態だったため、暗号化してuser_idを推測されないようにした。
### 参考資料
#### ハッシュ化のやり方
https://qiita.com/sasakura_870/items/3aa0a6e37c5e8fc780cc
https://qiita.com/NaokiIshimura/items/0a0168f9729f49f24682
https://zenn.dev/harasho/articles/hash-id-rails
https://docs.ruby-lang.org/ja/latest/class/Digest=3a=3aBase.html#I_HEXDIGEST
#### 単一カラムの更新について
https://techracho.bpsinc.jp/hachi8833/2018_12_10/66145
https://qiita.com/tyamagu2/items/8abd93bb7ab0424cf084
https://www.techscore.com/blog/2012/12/25/rails%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%AB%E3%83%90%E3%83%83%E3%82%AF%E3%81%BE%E3%81%A8%E3%82%81/
https://www.audia.jp/blog/rubyonrails-activerecord-update-method-comparison/