### PR TITLE
コントローラで行っていたカレンダーファイルのレンダリングをviewに移した

### DIFF
--- a/app/controllers/users/subscriptions_controller.rb
+++ b/app/controllers/users/subscriptions_controller.rb
@@ -5,13 +5,8 @@ module Users
     skip_before_action :authenticate, raise: false, only: :index
 
     def index
-      respond_to do |format|
-        format.ics do
-          calendar = SubscriptionsInIcalFormatExporter.export_subscriptions(set_export)
-          calendar.publish
-          render plain: calendar.to_ical
-        end
-      end
+      @calendar = SubscriptionsInIcalFormatExporter.export_subscriptions(set_export)
+      @calendar.publish
     end
 
     private

--- a/app/views/users/subscriptions/index.ics.slim
+++ b/app/views/users/subscriptions/index.ics.slim
@@ -1,0 +1,1 @@
+= render plain: @calendar.to_ical

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,0 +1,1 @@
+Mime::Type.register "text/calendar", :ics


### PR DESCRIPTION
## issue
- #219 
### 概要
レビューにてコントローラ側で行っていたカレンダーファイルのレンダリングはview側の処理の方が良いとアドバイスいただいたため対応した

### 参考資料
https://stackoverflow.com/questions/6848178/create-ics-ical-from-a-view
https://github.com/mikel/rails-examples/blob/master/config/initializers/mime_types.rb